### PR TITLE
mvn registry for specification coordinates

### DIFF
--- a/MAVEN.md
+++ b/MAVEN.md
@@ -1,0 +1,23 @@
+# Specification Maven Coordinates
+
+## Expression Language (EL) API
+ - jakarta.el:el-api
+
+
+## [Java Server Pages (JSP) API](https://github.com/eclipse-ee4j/jsp-api)
+ - jakarta.servlet.jsp:jsp-api
+ - jakarta.servlet.jsp:jstl-api
+
+
+## [Servlet API](https://github.com/eclipse-ee4j/servlet-api)
+ - jakarta.servlet:servlet-api
+
+
+## [JAXRS API](https://github.com/eclipse-ee4j/jaxrs-api)
+ - jakarta.ws:rs-api
+
+
+## [Websocket API](https://github.com/eclipse-ee4j/websocket-api)
+ - jakarta.websocket:websocket-all
+ - jakarta.websocket:websocket-api
+ - jakarta.websocket:websocket-client-api


### PR DESCRIPTION
This is a sample tracking file providing the ee4j project a registry for specification coordinates in maven central.  Maven is a durable, write once repository and we have one shot at keeping it a clean looking experience.  Before projects start pushing their artifacts into central without any guidelines, it might be useful to make sure there is one place containing all groupIds and artifactIds so we ensure consistency in naming conventions.

Signed-off-by: Jesse McConnell <jesse.mcconnell@gmail.com>