### PR TITLE
Add configuration for the nexus-staging-maven-plugin.

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -158,7 +158,6 @@
     </build>
 
     <profiles>
-
         <!--
             This profile provides configuration for the plugins that required in
             order to deploy non SNAPSHOT artifacts.

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -159,7 +159,7 @@
 
     <profiles>
         <!--
-            This profile provides configuration for the plugins that required in
+            This profile provides configuration for the plugins that are required are in
             order to deploy non SNAPSHOT artifacts.
             SNAPSHOT artifacts can be deployed without using any profile.
         -->

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -149,7 +149,7 @@
                         <serverId>ossrh</serverId>
                         <nexusUrl>https://oss.sonatype.org/</nexusUrl>
                         <autoReleaseAfterClose>false</autoReleaseAfterClose>
-                        <!-- Skip based on the well known maven.deploy.skip property -->
+                        <!-- Skip based on the maven.deploy.skip property -->
                         <skipNexusStagingDeployMojo>${maven.deploy.skip}</skipNexusStagingDeployMojo>
                     </configuration>
                 </plugin>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -114,8 +114,8 @@
         <sonatypeOssDistMgmtReleasesUrl>https://oss.sonatype.org/service/local/staging/deploy/maven2/</sonatypeOssDistMgmtReleasesUrl>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <!--
-          intialize release.arguments to empty, otherwise if not defined
-          it can fail the release plugin
+          Initialize release.arguments to empty, otherwise if not defined
+          it can fail the release plugin.
         -->
         <release.arguments></release.arguments>
     </properties>
@@ -133,11 +133,37 @@
                         <arguments>-Poss-release ${release.arguments}</arguments>
                     </configuration>
                 </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-deploy-plugin</artifactId>
+                    <configuration>
+                        <!-- To prefer nexus-staging-maven-plugin -->
+                        <skip>true</skip>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.sonatype.plugins</groupId>
+                    <artifactId>nexus-staging-maven-plugin</artifactId>
+                    <version>1.6.8</version>
+                    <configuration>
+                        <serverId>ossrh</serverId>
+                        <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+                        <autoReleaseAfterClose>false</autoReleaseAfterClose>
+                        <!-- Skip based on the well known maven.deploy.skip property -->
+                        <skipNexusStagingDeployMojo>${maven.deploy.skip}</skipNexusStagingDeployMojo>
+                    </configuration>
+                </plugin>
             </plugins>
         </pluginManagement>
     </build>
 
     <profiles>
+
+        <!--
+            This profile provides configuration for the plugins that required in
+            order to deploy non SNAPSHOT artifacts.
+            SNAPSHOT artifacts can be deployed without using any profile.
+        -->
         <profile>
             <id>oss-release</id>
             <build>
@@ -190,6 +216,8 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
+                        <!-- Older versions have issues with the gpg passphrase -->
+                        <version>1.6</version>
                         <configuration>
                             <gpgArguments>
                                 <arg>--pinentry-mode</arg>
@@ -206,10 +234,37 @@
                             </execution>
                         </executions>
                     </plugin>
+                    <plugin>
+                        <groupId>org.sonatype.plugins</groupId>
+                        <artifactId>nexus-staging-maven-plugin</artifactId>
+                        <extensions>true</extensions>
+                    </plugin>
                 </plugins>
             </build>
         </profile>
 
+        <!--
+            The nexus-staging-maven-plugin is configured in the oss-release
+            profile, however it configures plugin executions which can be undesired.
+            This profile only enables the nexus-staging-maven-plugin.
+        -->
+        <profile>
+            <id>nexus-plugin</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.sonatype.plugins</groupId>
+                        <artifactId>nexus-staging-maven-plugin</artifactId>
+                        <extensions>true</extensions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <!--
+            This profile enables consuming snapshot artifacts from the ossrh
+            snapshots repository.
+        -->
         <profile>
             <id>snapshots</id>
             <activation>
@@ -243,6 +298,10 @@
             </pluginRepositories>
         </profile>
 
+        <!--
+            This profile enables consuming artifacts from the ossrh staging
+            repository group.
+        -->
         <profile>
             <id>staging</id>
             <activation>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -244,24 +244,6 @@
         </profile>
 
         <!--
-            The nexus-staging-maven-plugin is configured in the oss-release
-            profile, however it configures plugin executions which can be undesired.
-            This profile only enables the nexus-staging-maven-plugin.
-        -->
-        <profile>
-            <id>nexus-plugin</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.sonatype.plugins</groupId>
-                        <artifactId>nexus-staging-maven-plugin</artifactId>
-                        <extensions>true</extensions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-
-        <!--
             This profile enables consuming snapshot artifacts from the ossrh
             snapshots repository.
         -->


### PR DESCRIPTION
This plugin requires to be declared with extension=true.
It is relatively intrusive, thus isolating it inside the oss-release profile.

The plugin also has "rc" goals that can be used with mvn cli invokation
 to automate the nexus workflow. The plugin is configured in pluginManagement to enable that use-case.

Configure the maven-deploy-plugin to be skipped so that it does not
 interfere with the nexus-staging-maven-plugin. Also configure the
 nexus-staging-maven-plugin to skip its execution based on maven.deploy.skip
 which is a well known property.

Add comments to clarify what each profile does.