### PR TITLE
Remove hardcoded skip of the deploy-plugin

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -134,14 +134,6 @@
                     </configuration>
                 </plugin>
                 <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-deploy-plugin</artifactId>
-                    <configuration>
-                        <!-- To prefer nexus-staging-maven-plugin -->
-                        <skip>true</skip>
-                    </configuration>
-                </plugin>
-                <plugin>
                     <groupId>org.sonatype.plugins</groupId>
                     <artifactId>nexus-staging-maven-plugin</artifactId>
                     <version>1.6.8</version>


### PR DESCRIPTION
Signed-off-by: Romain Grecourt <romain.grecourt@oracle.com>

Round 2 for parent pom update. See https://github.com/eclipse-ee4j/ee4j/pull/38
@Tomas-Kraus FYI