### PR TITLE
Set explicit plugin versions

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -164,6 +164,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-enforcer-plugin</artifactId>
+                        <version>3.0.0-M3</version>
                         <executions>
                             <execution>
                                 <id>enforce-maven</id>
@@ -185,6 +186,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-source-plugin</artifactId>
+                        <version>3.2.0</version>
                         <executions>
                             <execution>
                                 <id>attach-sources</id>
@@ -197,6 +199,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
+                        <version>3.1.1</version>
                         <executions>
                             <execution>
                                 <id>attach-javadocs</id>


### PR DESCRIPTION
Fixes here:
```
[WARNING] Some problems were encountered while building the effective model for org.eclipse.ee4j:project:pom:1.0.6-SNAPSHOT
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-source-plugin is missing. @ line 185, column 29
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-javadoc-plugin is missing. @ line 197, column 29
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-enforcer-plugin is missing. @ line 164, column 29
[WARNING]
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING]
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
```
and the same in children using oss-release profile, for example in [jsonp](https://travis-ci.org/eclipse-ee4j/jsonp/jobs/652082421#L633).