### PR TITLE
prepare Reproducible Builds

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -107,6 +107,7 @@
           it can fail the release plugin.
         -->
         <release.arguments></release.arguments>
+        <project.build.outputTimestamp>2020-12-19T17:24:00Z</project.build.outputTimestamp>
     </properties>
 
     <distributionManagement>
@@ -128,7 +129,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-release-plugin</artifactId>
-                    <version>2.5.3</version>
+                    <version>3.0.0-M6</version>
                     <configuration>
                         <mavenExecutorId>forked-path</mavenExecutorId>
                         <useReleaseProfile>false</useReleaseProfile>
@@ -151,6 +152,11 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-enforcer-plugin</artifactId>
                     <version>3.0.0-M3</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-jar-plugin</artifactId>
+                    <version>3.3.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
see https://maven.apache.org/guides/mini/guide-reproducible-builds.html

upgrading maven-release-plugin will permit automatic update of `project.build.outputTimestamp` property when doing the release

reproducible releases can then be checked and added to https://github.com/jvm-repo-rebuild/reproducible-central