### PR TITLE
Drop expressions in repository URLs and manage version of Maven Install Plugin

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -171,6 +171,11 @@
                     <!-- Older versions have issues with the gpg passphrase -->
                     <version>3.0.1</version>
                 </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-install-plugin</artifactId>
+                    <version>3.1.0</version>
+                </plugin>
             </plugins>
         </pluginManagement>
     </build>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -98,10 +98,6 @@
     </mailingLists>
 
     <properties>
-        <sonatypeOssDistMgmtNexusUrl>https://jakarta.oss.sonatype.org/</sonatypeOssDistMgmtNexusUrl>
-        <sonatypeOssDistMgmtSnapshotsUrl>${sonatypeOssDistMgmtNexusUrl}content/repositories/snapshots/</sonatypeOssDistMgmtSnapshotsUrl>
-        <sonatypeOssDistMgmtStagingUrl>${sonatypeOssDistMgmtNexusUrl}content/repositories/staging/</sonatypeOssDistMgmtStagingUrl>
-        <sonatypeOssDistMgmtReleasesUrl>${sonatypeOssDistMgmtNexusUrl}service/local/staging/deploy/maven2/</sonatypeOssDistMgmtReleasesUrl>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <!--
           Initialize release.arguments to empty, otherwise if not defined
@@ -115,12 +111,12 @@
         <snapshotRepository>
             <id>ossrh</id>
             <name>Sonatype Nexus Snapshots</name>
-            <url>${sonatypeOssDistMgmtSnapshotsUrl}</url>
+            <url>https://jakarta.oss.sonatype.org/content/repositories/snapshots/</url>
         </snapshotRepository>
         <repository>
             <id>ossrh</id>
             <name>Sonatype Nexus Releases</name>
-            <url>${sonatypeOssDistMgmtReleasesUrl}</url>
+            <url>https://jakarta.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
         </repository>
     </distributionManagement>
 
@@ -275,7 +271,7 @@
                 <repository>
                     <id>sonatype-nexus-snapshots</id>
                     <name>Sonatype Nexus Snapshots</name>
-                    <url>${sonatypeOssDistMgmtSnapshotsUrl}</url>
+                    <url>https://jakarta.oss.sonatype.org/content/repositories/snapshots/</url>
                     <releases>
                         <enabled>false</enabled>
                     </releases>
@@ -288,7 +284,7 @@
                 <pluginRepository>
                     <id>sonatype-nexus-snapshots</id>
                     <name>Sonatype Nexus Snapshots</name>
-                    <url>${sonatypeOssDistMgmtSnapshotsUrl}</url>
+                    <url>https://jakarta.oss.sonatype.org/content/repositories/snapshots/</url>
                     <releases>
                         <enabled>false</enabled>
                     </releases>
@@ -312,7 +308,7 @@
                 <repository>
                     <id>sonatype-nexus-staging</id>
                     <name>Sonatype Nexus Staging</name>
-                    <url>${sonatypeOssDistMgmtStagingUrl}</url>
+                    <url>https://jakarta.oss.sonatype.org/content/repositories/staging/</url>
                     <releases>
                         <enabled>true</enabled>
                     </releases>
@@ -325,7 +321,7 @@
                 <pluginRepository>
                     <id>sonatype-nexus-staging</id>
                     <name>Sonatype Nexus Staging</name>
-                    <url>${sonatypeOssDistMgmtStagingUrl}</url>
+                    <url>https://jakarta.oss.sonatype.org/content/repositories/staging/</url>
                     <releases>
                         <enabled>true</enabled>
                     </releases>


### PR DESCRIPTION
Following the conversation in #84, here's a pull request that does the trivial changes:

- Replace expressions in URLs with their actual values.
- Pin versions of plugins

There's one more thing that must be done. If you would attempt to make a release, it would fail with
```
The maven-gpg-plugin is not supported by Maven 4. Verify if there is a compatible signing solution, add -Dmaven.experimental.buildconsumer=false or use Maven 3.
```

The [Sign Maven Plugin](https://www.simplify4u.org/sign-maven-plugin/) looks like a candidate replacement. Its website says it works on Maven 3.6 and is ready for Maven 4 with Consumer POM.

Since the Sign Maven Plugin does not look like a drop-in replacement to me, and since it is not part of the ASF Maven project, I chose not to include it (yet) in this PR. If the Eclipse EE4J project decides to adopt that plugin, it could be part of this PR.