### PR TITLE
Inline repository URLs

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2022 Contributors to the Eclipse Foundation. All rights reserved.
+    Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation. All rights reserved.
     Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -317,7 +317,7 @@
                 <repository>
                     <id>sonatype-nexus-snapshots</id>
                     <name>Sonatype Nexus Snapshots</name>
-                    <url>${sonatypeOssDistMgmtSnapshotsUrl}</url>
+                    <url>https://jakarta.oss.sonatype.org/content/repositories/snapshots/</url>
                     <releases>
                         <enabled>false</enabled>
                     </releases>
@@ -330,7 +330,7 @@
                 <pluginRepository>
                     <id>sonatype-nexus-snapshots</id>
                     <name>Sonatype Nexus Snapshots</name>
-                    <url>${sonatypeOssDistMgmtSnapshotsUrl}</url>
+                    <url>https://jakarta.oss.sonatype.org/content/repositories/snapshots/</url>
                     <releases>
                         <enabled>false</enabled>
                     </releases>
@@ -354,7 +354,7 @@
                 <repository>
                     <id>sonatype-nexus-staging</id>
                     <name>Sonatype Nexus Staging</name>
-                    <url>${sonatypeOssDistMgmtStagingUrl}</url>
+                    <url>https://jakarta.oss.sonatype.org/content/repositories/staging/</url>
                     <releases>
                         <enabled>true</enabled>
                     </releases>
@@ -367,7 +367,7 @@
                 <pluginRepository>
                     <id>sonatype-nexus-staging</id>
                     <name>Sonatype Nexus Staging</name>
-                    <url>${sonatypeOssDistMgmtStagingUrl}</url>
+                    <url>https://jakarta.oss.sonatype.org/content/repositories/staging/</url>
                     <releases>
                         <enabled>true</enabled>
                     </releases>


### PR DESCRIPTION
Avoid with maven 4:
```
[ERROR] Some problems were encountered while processing the POMs [ERROR] The build could not read 1 project -> [Help 1] [ERROR]
[ERROR]   The project org.eclipse.ee4j:project:1.0.10-SNAPSHOT (.../parent/pom.xml) has 4 errors
[ERROR]     'profiles.profile[snapshots].repositories.repository.[sonatype-nexus-snapshots].url' contains an expression but should be a constant. @ line 325, column 21
[ERROR]     'profiles.profile[snapshots].pluginRepositories.pluginRepository.[sonatype-nexus-snapshots].url' contains an expression but should be a constant. @ line 338, column 21
[ERROR]     'profiles.profile[staging].repositories.repository.[sonatype-nexus-staging].url' contains an expression but should be a constant. @ line 362, column 21
[ERROR]     'profiles.profile[staging].pluginRepositories.pluginRepository.[sonatype-nexus-staging].url' contains an expression but should be a constant. @ line 375, column 21
```