### PR TITLE
Explicit version of m-install-p

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2022 Contributors to the Eclipse Foundation. All rights reserved.
+    Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation. All rights reserved.
     Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -174,6 +174,11 @@
                     <artifactId>maven-gpg-plugin</artifactId>
                     <!-- Older versions have issues with the gpg passphrase -->
                     <version>3.1.0</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-install-plugin</artifactId>
+                    <version>3.1.3</version>
                 </plugin>
                 <plugin>
                     <groupId>org.cyclonedx</groupId>


### PR DESCRIPTION
Avoid:
```
[WARNING] Version not locked for default bindings plugins [maven-install-plugin], you should define versions in pluginManagement section of your pom.xml or parent
```