### PR TITLE
dependency: update central-staging-plugins

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -118,7 +118,7 @@
                 <plugin>
                     <groupId>org.eclipse.cbi.central</groupId>
                     <artifactId>central-staging-plugins</artifactId>
-                    <version>1.4.3</version>
+                    <version>1.4.4</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -118,7 +118,7 @@
                 <plugin>
                     <groupId>org.eclipse.cbi.central</groupId>
                     <artifactId>central-staging-plugins</artifactId>
-                    <version>1.4.4</version>
+                    <version>1.4.5</version> <!-- TODO update to 1.4.6 when available-->
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -482,6 +482,7 @@
                                     <signArtifacts>true</signArtifacts>
                                     <syncAutoPublish>true</syncAutoPublish>
                                     <syncDropAfterPublish>true</syncDropAfterPublish>
+                                    <downloadAdditionalClassifiers>cyclonedx.json,cyclonedx.json.asc,cyclonedx.json.md5,cyclonedx.json.sha1,cyclonedx.xml,cyclonedx.xml.asc,cyclonedx.xml.md5,cyclonedx.xml.sha1,</downloadAdditionalClassifiers>
                                 </configuration>
                             </execution>
                         </executions>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -118,7 +118,7 @@
                 <plugin>
                     <groupId>org.eclipse.cbi.central</groupId>
                     <artifactId>central-staging-plugins</artifactId>
-                    <version>1.4.5</version> <!-- TODO update to 1.4.6 when available-->
+                    <version>1.4.6</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -482,7 +482,7 @@
                                     <signArtifacts>true</signArtifacts>
                                     <syncAutoPublish>true</syncAutoPublish>
                                     <syncDropAfterPublish>true</syncDropAfterPublish>
-                                    <downloadAdditionalClassifiers>cyclonedx.json,cyclonedx.json.asc,cyclonedx.json.md5,cyclonedx.json.sha1,cyclonedx.xml,cyclonedx.xml.asc,cyclonedx.xml.md5,cyclonedx.xml.sha1,</downloadAdditionalClassifiers>
+                                    <nexusArtifactsResolution>true</nexusArtifactsResolution> <!-- Ensure all artifacts are resolved; not just the base, pom, sources, and javadoc -->
                                 </configuration>
                             </execution>
                         </executions>


### PR DESCRIPTION
See changes here: https://github.com/eclipse-cbi/central-staging-plugins/commit/150a78f81fdbd4d2eb3d68a1641f773304e74860#diff-77c616df76b1abb5e8618c8d2fd0e5c7314ac4366d0af16868700cdb230a454d

Updates the API URL from repo3.eclipse.org -> repo.eclipse.org
Concurrency was able to use the plugin without this update see: https://ci.eclipse.org/cu/view/Release%20Builds/job/concurrency_api_1-build-and-stage/44/
My assumption is that it worked because of the URL redirect. 
~I'll leave it up to the maintainers of this project to decide when they want to put this change in since a minor release was just published today~

Plugin now allows for syncing all artifacts from staging to central including SBOM files. 

Fixes #123 