### PR TITLE
Update central-staging-plugins to 1.4.7

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -118,7 +118,7 @@
                 <plugin>
                     <groupId>org.eclipse.cbi.central</groupId>
                     <artifactId>central-staging-plugins</artifactId>
-                    <version>1.4.6</version>
+                    <version>1.4.7</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
1.4.7 fixes the issue with `nexusArtifactsResolution` being ignored during `rc-sync`.

See also:
* https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/6890#note_7307659
* https://github.com/eclipse-cbi/central-staging-plugins/pull/11

With this, I was able to cut a release that published all artifacts from staging repo.
The only difference is that any additional files won't have `.sha256` and `.sha512` checkcums but will have all the other bits.

Here's an example release of [CDI TCK Alpha7](https://repo1.maven.org/maven2/jakarta/cdi/jakarta.cdi-tck-core-impl/5.0.0.Alpha7/) with ton of extra files.

CC @KyleAure @ivargrimstad 

We should probably issue another minor release with this.
Hopefully, the last one :)