### PR TITLE
CycloneDX files moved to release profiles

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -166,40 +166,6 @@
     </build>
 
     <profiles>
-
-        <profile>
-        <!-- Generates SBOM. Skip with '-DskipSBOM'.-->
-            <id>sbom</id>
-            <activation>
-              <property>
-                <name>!skipSBOM</name>
-              </property>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.cyclonedx</groupId>
-                        <artifactId>cyclonedx-maven-plugin</artifactId>
-                        <configuration>
-                            <schemaVersion>1.4</schemaVersion>
-                            <projectType>library</projectType>
-                            <!-- Without this it doesn't generate cyclonedx files at all. -->
-                            <!-- Watch https://github.com/CycloneDX/cyclonedx-maven-plugin/issues/597 -->
-                            <skipNotDeployed>false</skipNotDeployed>
-                        </configuration>
-                        <executions>
-                            <execution>
-                                <phase>package</phase>
-                                <goals>
-                                    <goal>makeAggregateBom</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-
         <!--
             This profile provides configuration for the plugins that are required in
             order to deploy both release and snapshot artifacts.
@@ -264,6 +230,25 @@
                                 <id>attach-javadocs</id>
                                 <goals>
                                     <goal>jar</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.cyclonedx</groupId>
+                        <artifactId>cyclonedx-maven-plugin</artifactId>
+                        <configuration>
+                            <schemaVersion>1.4</schemaVersion>
+                            <projectType>library</projectType>
+                            <!-- Without this it doesn't generate cyclonedx files at all. -->
+                            <!-- Watch https://github.com/CycloneDX/cyclonedx-maven-plugin/issues/597 -->
+                            <skipNotDeployed>false</skipNotDeployed>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>makeAggregateBom</goal>
                                 </goals>
                             </execution>
                         </executions>
@@ -372,6 +357,25 @@
                                 <id>attach-javadocs</id>
                                 <goals>
                                     <goal>jar</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.cyclonedx</groupId>
+                        <artifactId>cyclonedx-maven-plugin</artifactId>
+                        <configuration>
+                            <schemaVersion>1.4</schemaVersion>
+                            <projectType>library</projectType>
+                            <!-- Without this it doesn't generate cyclonedx files at all. -->
+                            <!-- Watch https://github.com/CycloneDX/cyclonedx-maven-plugin/issues/597 -->
+                            <skipNotDeployed>false</skipNotDeployed>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>makeAggregateBom</goal>
                                 </goals>
                             </execution>
                         </executions>


### PR DESCRIPTION
- They are not useful for us in development, but they are required to be published to Maven Central.
- The `sbom` profile was enabled by default, we had to override it
- `-Dcyclonedx.skip` would skip the plugin execution
- `-Dcyclonedx.skipAttach` executes the plugin, but doesn't deploy files.
- Tested locally on GlassFish with `-Poss-release` or `-Pstage-release` enable it, in combination with "skips" too.
- Some docs for the plugin: https://github.com/CycloneDX/cyclonedx-maven-plugin

### Summary of the change:
* The `sbom` profile was deleted
* the cyclonedx maven plugin execution was added to `oss-release` profile and to `stage-release` profile.